### PR TITLE
Populate required package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,15 @@
 {
+  "name": "bs-transit-js",
+  "version": "0.0.1",
+  "description": "BuckleScript bindings for transit-js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BuckleTypes/bs-transit-js"
+  },
+  "homepage": "https://github.com/BuckleTypes/bs-transit-js",
+    "keywords": [ "reason", "cqrs", "bucklescript" ],
   "devDependencies": {
-    "bs-platform": "^1.4.1",
+    "bs-platform": "^1.7.1",
     "transit-js": "^0.8.846"
   },
   "scripts": {


### PR DESCRIPTION
Name, repository and other required fields. It does not add a license.